### PR TITLE
konvoy: bump version, don't cleanup output/, copy public key to a different dir

### DIFF
--- a/build/rpms/build.sh
+++ b/build/rpms/build.sh
@@ -70,7 +70,7 @@ EOF
 
   rpm --addsign /root/rpmbuild/RPMS/${RPMARCH}/*.rpm
 
-  createrepo -o "/root/rpmbuild/RPMS/${RPMARCH}/" "/root/rpmbuild/RPMS/${RPMARCH}"
+  createrepo --update --database -o "/root/rpmbuild/RPMS/${RPMARCH}/" "/root/rpmbuild/RPMS/${RPMARCH}"
 
   gpg --detach-sign --armor /root/rpmbuild/RPMS/${RPMARCH}/repodata/repomd.xml
 
@@ -78,4 +78,4 @@ done
 
 
 echo "Copying public key to output"
-cp /tmp/rpm-gpg-pub-key /root/rpmbuild/RPMS/${RPMARCH}/rpm-gpg-pub-key
+cp /tmp/rpm-gpg-pub-key /root/rpmbuild/RPMS/rpm-gpg-pub-key

--- a/build/rpms/docker-build.sh
+++ b/build/rpms/docker-build.sh
@@ -2,8 +2,6 @@
 set -e
 
 docker build -t kubelet-rpm-builder .
-echo "Cleaning output directory..."
-sudo rm -rf output/*
 mkdir -p output
 if [ -z "$GPG_KEY_FILE" ]; then
     echo "gpg key 'GPG_KEY_FILE' env var is required to sign the rpm packages and repo metadata"

--- a/build/rpms/kubelet.spec
+++ b/build/rpms/kubelet.spec
@@ -1,6 +1,6 @@
 %global KUBE_MAJOR 1
 %global KUBE_MINOR 15
-%global KUBE_PATCH 1
+%global KUBE_PATCH 2
 %global KUBE_VERSION %{KUBE_MAJOR}.%{KUBE_MINOR}.%{KUBE_PATCH}
 %global RPM_RELEASE 0
 %global ARCH amd64


### PR DESCRIPTION
Changes used to build the packages that were tested with in CI.